### PR TITLE
Enable checkBenevolentUnionTypes and remove invalid DOMExceptions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require-dev": {
         "editorconfig-checker/editorconfig-checker": "10.7.0",
         "ergebnis/composer-normalize": "2.48.2",
-        "phpstan/phpstan": "2.1.42",
+        "phpstan/phpstan": "2.1.43",
         "phpstan/phpstan-phpunit": "2.0.16",
         "phpstan/phpstan-strict-rules": "2.0.10",
         "phpunit/php-code-coverage": "^10.1",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -22,7 +22,7 @@ parameters:
     internalErrorsCountLimit: 1
     checkMissingCallableSignature: true
     checkUninitializedProperties: true
-    checkBenevolentUnionTypes: false # true not usable with DOMDocument::createElement usages: https://github.com/phpstan/phpstan/issues/13792
+    checkBenevolentUnionTypes: true
     checkImplicitMixed: true
     checkTooWideReturnTypesInProtectedAndPublicMethods: true
     checkTooWideThrowTypesInProtectedAndPublicMethods: true

--- a/src/Writer/CloverCoverageWriter.php
+++ b/src/Writer/CloverCoverageWriter.php
@@ -4,8 +4,6 @@ namespace ShipMonk\CoverageGuard\Writer;
 
 use DOMDocument;
 use DOMElement;
-use DOMException;
-use LogicException;
 use ShipMonk\CoverageGuard\Coverage\FileCoverage;
 use ShipMonk\CoverageGuard\Exception\ErrorException;
 use ShipMonk\CoverageGuard\Utils\Indenter;
@@ -27,11 +25,7 @@ final class CloverCoverageWriter implements CoverageWriter
         string $indent,
     ): string
     {
-        try {
-            $dom = $this->generateXml($fileCoverages);
-        } catch (DOMException $e) {
-            throw new LogicException('Failed to generate clover XML: ' . $e->getMessage(), 0, $e);
-        }
+        $dom = $this->generateXml($fileCoverages);
         $xml = $dom->saveXML();
 
         if ($xml === false) {
@@ -44,7 +38,6 @@ final class CloverCoverageWriter implements CoverageWriter
     /**
      * @param array<FileCoverage> $fileCoverages
      *
-     * @throws DOMException
      * @throws ErrorException
      */
     private function generateXml(array $fileCoverages): DOMDocument
@@ -73,9 +66,6 @@ final class CloverCoverageWriter implements CoverageWriter
         return $dom;
     }
 
-    /**
-     * @throws DOMException
-     */
     private function addFileElement(
         DOMDocument $dom,
         DOMElement $project,

--- a/src/Writer/CoberturaCoverageWriter.php
+++ b/src/Writer/CoberturaCoverageWriter.php
@@ -113,9 +113,6 @@ final class CoberturaCoverageWriter implements CoverageWriter
         return $dom;
     }
 
-    /**
-     * @throws DOMException
-     */
     private function addSource(
         DOMDocument $dom,
         DOMElement $coverage,
@@ -182,8 +179,6 @@ final class CoberturaCoverageWriter implements CoverageWriter
 
     /**
      * @param array<FileCoverage> $fileCoverages
-     *
-     * @throws DOMException
      */
     private function addPackages(
         DOMDocument $dom,
@@ -213,9 +208,6 @@ final class CoberturaCoverageWriter implements CoverageWriter
         }
     }
 
-    /**
-     * @throws DOMException
-     */
     private function createPackageElement(
         DOMDocument $dom,
         float $lineRate,
@@ -231,9 +223,6 @@ final class CoberturaCoverageWriter implements CoverageWriter
         return $packageElement;
     }
 
-    /**
-     * @throws DOMException
-     */
     private function createClassElement(
         DOMDocument $dom,
         FileCoverage $fileCoverage,
@@ -287,9 +276,6 @@ final class CoberturaCoverageWriter implements CoverageWriter
         throw new LogicException("File path '$filePath' is not within source directory '$sourceDir', broken source detection?");
     }
 
-    /**
-     * @throws DOMException
-     */
     private function addLines(
         DOMDocument $dom,
         DOMElement $classElement,


### PR DESCRIPTION
Bump phpstan to [2.1.43](https://github.com/phpstan/phpstan/releases/tag/2.1.43) which [now](https://github.com/phpstan/phpstan-src/pull/5192) resolves the `DOMDocument::createElement` benevolent union issue, allowing `checkBenevolentUnionTypes` to be enabled. Remove now-unnecessary `DOMException` catches and `@throws` annotations.