### PR TITLE
Upgrade shipmonk/dead-code-detector to ^1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "sebastian/diff": "^4.0 || ^5.0 || ^6.0 || ^7.0",
         "shipmonk/coding-standard": "^0.2.4",
         "shipmonk/composer-dependency-analyser": "1.8.4",
-        "shipmonk/dead-code-detector": "0.15.1",
+        "shipmonk/dead-code-detector": "^1.0",
         "shipmonk/name-collision-detector": "2.1.1",
         "shipmonk/phpstan-rules": "4.3.6"
     },


### PR DESCRIPTION
## Summary
- Upgrade `shipmonk/dead-code-detector` from `0.15.1` to `^1.0`

Co-Authored-By: Claude Code