### PR TITLE
Bump phpstan to 2.2 and fix violations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
     "require-dev": {
         "editorconfig-checker/editorconfig-checker": "10.7.0",
         "ergebnis/composer-normalize": "2.48.2",
-        "phpstan/phpstan": "2.1.43",
+        "phpstan/phpstan": "2.2.0",
         "phpstan/phpstan-phpunit": "2.0.16",
-        "phpstan/phpstan-strict-rules": "2.0.10",
+        "phpstan/phpstan-strict-rules": "2.0.11",
         "phpunit/php-code-coverage": "^10.1",
         "phpunit/phpunit": "~10.5.58",
         "sebastian/diff": "^4.0 || ^5.0 || ^6.0 || ^7.0",

--- a/tests/CoverageGuardTest.php
+++ b/tests/CoverageGuardTest.php
@@ -54,7 +54,7 @@ final class CoverageGuardTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array{array{string, string|null, bool}}>
+     * @return iterable<string, array{array{string, string|null, bool}, 1?: callable(Config): void}>
      */
     public static function provideArgs(): iterable
     {


### PR DESCRIPTION
## Summary
- Upgrade `phpstan/phpstan` 2.1.43 → 2.2.0 (and `phpstan-strict-rules` 2.0.10 → 2.0.11)
- Fix `generator.valueType` error in `CoverageGuardTest::provideArgs()`: the `@return` tuple shape was missing the optional second element (the `Closure(Config): void` config-adjuster used in the `'with path mapping'` case)

## Test plan
- [x] `composer check` passes (cs, types, collisions, deps, self-coverage, tests)

Co-Authored-By: Claude Code